### PR TITLE
feat(ci): Add initial workflows

### DIFF
--- a/.github/workflows/actions-lint.yaml
+++ b/.github/workflows/actions-lint.yaml
@@ -1,0 +1,37 @@
+name: Lint/Validate Github Actions files
+
+on:
+  workflow_call:
+
+jobs:
+  lint_validate_actions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout Actoinlint Configs
+        uses: actions/checkout@v3
+        with:
+          repository: circlefin/circle-public-github-workflows
+          ref: stable
+          path: .actionlint
+          sparse-checkout: |-
+            config/linters
+
+      - name: Run actionlint
+        env:
+          ACTIONLINT_DL: https://github.com/rhysd/actionlint/releases/download/v1.6.26/actionlint_1.6.26_linux_amd64.tar.gz
+          ACTIONLINT_SHA: f0294c342af98fad4ff917bc32032f28e1b55f76aedf291886ec10bbed7c12e1
+        shell: bash
+        run: |
+          echo "::add-matcher::.actionlint/config/linters/actionlint-matcher.json"
+          curl -sSfLo "${RUNNER_TEMP}/actionlint.tar.gz" ${ACTIONLINT_DL}
+          sha256sum -c <<< "${ACTIONLINT_SHA} ${RUNNER_TEMP}/actionlint.tar.gz"
+          tar xvzf ${RUNNER_TEMP}/actionlint.tar.gz actionlint
+
+          ./actionlint -color -shellcheck="" --config-file .actionlint/config/linters/actionlint.yaml
+
+      - name: json-yaml-validate
+        uses: GrantBirki/json-yaml-validate@v2.3.1
+        with:
+          comment: true

--- a/.github/workflows/attach-release-assets.yaml
+++ b/.github/workflows/attach-release-assets.yaml
@@ -1,0 +1,220 @@
+# Attach assets to an existing release, or create a new release and attach assets.
+# Optionally generate an SBOM from Github Dependency graph and include it as an asset.
+name: release-attach-assets
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: |
+          Tag name to create (or use if it already exists) for the release.
+          If the release already exists, assets will be attached to it.
+          If unset, a timestamped release will be created.
+        type: string
+        required: false
+        default: ''
+      artifact_file_globs:
+        description: |
+          Newline-separated list of additional glob patterns to find in build artifacts.
+          Only files which are stored as build artifacts in a previous job will be included.
+          See [glob-match](https://github.com/marketplace/actions/glob-match) action for details.
+        type: string
+        required: false
+        default: ''
+      create_manifest:
+        description: |
+          Generate a manifest file containing the SHA256 checksums of included files.
+        type: boolean
+        required: false
+        default: true
+      manifest_filename:
+        description: |
+          Name of manifest file to create. May be useful to override in the case of multiple runs
+          of this workflow since filenames can't be repeated in a release.
+        type: string
+        required: false
+        default: MANIFEST
+      generate_sbom:
+        description: |
+          Generate an SPDX-formatted SBOM from Github dependency graph and include it
+          as an attached asset.
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  release_attach_assets:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v3
+        if: inputs.artifact_file_globs != ''
+        id: download-artifacts
+        with:
+          path: artifacts
+
+      - name: Perform setup
+        shell: bash
+        id: setup
+        env:
+          TAG: ${{ inputs.release_tag }}
+        run: |-
+          # Create assets directory
+          ASSETS_DIR="${RUNNER_TEMP}/assets"
+          mkdir -p $ASSETS_DIR
+          echo "ASSETS_DIR=${ASSETS_DIR}" >> ${GITHUB_ENV}
+
+          if [ -z "${TAG}" ]; then
+            TAG="release-$(date '+%Y-%m-%dT%H:%M:%S')"
+          fi
+          echo "tag=${TAG}" >> ${GITHUB_OUTPUT}
+
+      - name: Generate SBOM from Dependency Graph
+        uses: actions/github-script@v7
+        if: inputs.generate_sbom
+        env:
+          RELEASE_TAG: ${{ steps.setup.outputs.tag }}
+        with:
+          script: |-
+            const fs = require('fs');
+            const path = require('path');
+            try {
+              const sbomResp = await github.rest.dependencyGraph.exportSbom({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              const fileName = `${context.repo.repo}-${process.env.RELEASE_TAG}-${context.sha}.spdx.json`;
+              fs.writeFileSync(path.join(process.env.ASSETS_DIR, fileName), JSON.stringify(sbomResp.data.sbom));
+            } catch (err) {
+              core.error(`Failed to export SBOM from Dependency Graph: ${err}`);
+              core.setFailed(err);
+            }
+
+      - name: Find matching files in build artifacts
+        uses: tj-actions/glob@v17
+        if: steps.download-artifacts.conclusion == 'success'
+        id: glob
+        with:
+          files: ${{ inputs.artifact_file_globs }}
+          working-directory: artifacts
+          match-directories: false
+          strip-top-level-dir: false
+
+      - name: Compile required assets
+        shell: bash
+        if: steps.glob.conclusion == 'success'
+        id: compile-assets
+        env:
+          PATHS_FILE: ${{ steps.glob.outputs.paths-output-file }}
+        run: |-
+          if [ -s "${PATHS_FILE}" ]; then
+            echo "Found the following matching artifacts: "
+            cat "${PATHS_FILE}"
+            while IFS="" read -r file || [ -n "$p" ]
+            do
+              mv "$file" ${ASSETS_DIR}/$(basename "$file")
+            done < "${PATHS_FILE}"
+          else
+            echo "No artifacts matched the specified patterns"
+          fi
+
+      - name: Generate manifest of assets
+        if: inputs.create_manifest
+        env:
+          MANIFEST_FILENAME: ${{ inputs.manifest_filename }}
+        run: |-
+          cd ${ASSETS_DIR}
+          sha256sum * | tee ${MANIFEST_FILENAME}
+
+      - name: Attach assets to release
+        uses: actions/github-script@v7
+        env:
+          RELEASE_TAG: ${{ steps.setup.outputs.tag }}
+        with:
+          script: |-
+            const fs = require('fs');
+            const assert = require('assert');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const commit = context.sha;
+            const assetsDir = process.env['ASSETS_DIR'];
+            const releaseTag = process.env['RELEASE_TAG'].trim();
+
+            if (releaseTag === '') {
+              core.setFailed('No release tag specified. Unable to proceed.');
+              process.exit();
+            }
+
+            // Fetch or create release
+            let resp;
+            try {
+              resp = await github.rest.repos.getReleaseByTag({
+                owner: owner,
+                repo: repo,
+                tag: releaseTag,
+              });
+            } catch(err) {
+              core.info(`Failed to fetch existing release with tag ${releaseTag}: ${err}`);
+              const createReleaseOpts = {
+                owner: owner,
+                repo: repo,
+                tag_name: releaseTag,
+                target_commitish: commit,
+                make_latest: 'true',
+              };
+              try {
+                core.info("Attempting to create new release");
+                try {
+                  resp = await github.rest.repos.createRelease({...createReleaseOpts, generate_release_notes: true});
+                } catch(err) {
+                  // If the body was too long, attempt to create the release without embedded release notes.
+                  if (err?.message?.includes("body is too long")) {
+                    core.warning(`Generated release notes too long. Creating release without notes. ${err}`);
+                    resp = await github.rest.repos.createRelease(createReleaseOpts);
+                  } else {
+                    throw err;
+                  }
+                }
+              } catch(err) {
+                core.error(`Failed to fetch or create release: ${err}`);
+              }
+            }
+
+            const releaseId = resp?.data?.id;
+            if (!releaseId) {
+              core.setFailed(`No release ID in response: ${resp}`);
+              process.exit();
+            }
+            core.notice(`Attaching assets to release ${resp.data.html_url}`)
+
+            const fileGlob = await glob.create(`${assetsDir}/*`, {
+              followSymbolicLinks: false,
+              matchDirectories: false,
+            });
+            for await (const file of fileGlob.globGenerator()) {
+              const baseName = file.split('/').pop();
+              core.info(`Attaching ${baseName} to release ${releaseId}`);
+
+              try {
+                const data = fs.readFileSync(file);
+                await github.rest.repos.uploadReleaseAsset({
+                  owner: owner,
+                  repo: repo,
+                  release_id: releaseId,
+                  name: baseName,
+                  data: data,
+                });
+              } catch(err) {
+                if (err?.status === 422) {
+                  core.warning(`A file named ${baseName} already exists in this release!`);
+                } else {
+                  core.error(`Failed to upload file ${file} to release: ${err}`);
+                  core.setFailed(err);
+                  process.exit();
+                }
+              }
+            }

--- a/.github/workflows/circle-public-workflows-pipeline.yaml
+++ b/.github/workflows/circle-public-workflows-pipeline.yaml
@@ -1,0 +1,33 @@
+name: CIRCLE-PUBLIC-GITHUB-WORKFLOWS Pipeline
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  # lint-actions:
+  #   if: github.event_name == 'pull_request'
+  #   uses: ./.github/workflows/actions-lint.yaml
+
+  # pr-scan:
+  #   if: github.event_name == 'pull_request'
+  #   uses: ./.github/workflows/pr-scan.yaml
+
+  conventional-commit-release:
+    uses: ./.github/workflows/conventional-commit-release.yaml
+    with:
+      release_type: simple
+      additional_unqualified_tags: true
+      extra_tags: stable
+    secrets:
+      RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  attach-assets:
+    uses: ./.github/workflows/attach-release-assets.yaml
+    needs:
+      - conventional-commit-release
+    if: needs.conventional-commit-release.outputs.release_created == 'true'
+    with:
+      release_tag: ${{ needs.conventional-commit-release.outputs.release_tag }}

--- a/.github/workflows/conventional-commit-release.yaml
+++ b/.github/workflows/conventional-commit-release.yaml
@@ -1,0 +1,270 @@
+name: Conventional Commit & Release Please
+
+on:
+  workflow_call:
+    inputs:
+      release_type:
+        description: |
+          The type of project to release.
+          See [release-please](https://github.com/google-github-actions/release-please-action#release-types-supported)
+          for a full list of supported release types
+        type: string
+        required: true
+      changelog_types:
+        description: "Additional changelog types to include. Should be a JSON-encoded array of objects."
+        type: string
+        required: false
+        default: "[]"
+      allowed_scopes:
+        description: "Comma-separated list of scopes which are allowed in commit message"
+        type: string
+        required: false
+        default: ""
+      allowed_subject_cases:
+        description: "Comma-separated list of subject cases which are allowed in commit message"
+        type: string
+        required: false
+        default: "lower-case,upper-case,camel-case,kebab-case,pascal-case,sentence-case,snake-case,start-case"
+      additional_unqualified_tags:
+        description: "Additional tags produced for major.minor and major"
+        type: boolean
+        required: false
+        default: true
+      include_v_in_tag:
+        description: "Whether or not include 'v' in tags and releases. Default true"
+        type: boolean
+        required: false
+        default: true
+      pull_request_title_template:
+        description: "Template for the release-please managed pull request title"
+        type: string
+        required: false
+        default: "chore${scope}: release${component} ${version} (auto-release)"
+      extra_files:
+        description: "Additional files to update using release please generic updater"
+        type: string
+        required: false
+      lint_commits:
+        description: "Whether or not commits should be linted in addition to pull request title"
+        type: boolean
+        required: false
+        default: true
+      extra_tags:
+        description: "Comma-separated list of additional tags to create on the release commit"
+        type: string
+        required: false
+        default: ""
+    outputs:
+      release_created:
+        description: "Whether or not a release has been created in this workflow instance"
+        value: ${{ jobs.release.outputs.release_created }}
+      release_tag:
+        description: "Main release tag associated with a created release"
+        value: ${{ jobs.release.outputs.release_tag }}
+      additional_tags:
+        description: "Additional release tags associated with a created release, when additional_unqualified_tags is set"
+        value: ${{ jobs.release.outputs.additional_tags }}
+      major_minor_tag:
+        description: "Major Minor tag associated with a created release, when additional_unqualified_tags is set"
+        value: ${{ jobs.release.outputs.major_minor_tag }}
+      major_tag:
+        description: "Major tag associated with a created release, when additional_unqualified_tags is set"
+        value: ${{ jobs.release.outputs.major_tag }}
+    secrets:
+      RELEASE_TOKEN:
+        description: Github PAT used for executing the release-please action. Only required for default branch builds.
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  commit-lint:
+    name: PR Title and Commits Lint
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Calculate Fetch Depth
+        if: inputs.lint_commits
+        id: fetch-depth
+        run: echo "depth=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repo
+        if: steps.fetch-depth.conclusion == 'success'
+        id: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: ${{ steps.fetch-depth.outputs.depth }}
+
+      - name: Fetch base ref
+        if: steps.checkout.conclusion == 'success'
+        run: git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+
+      - name: Install commitlint
+        run: |
+          npm install -g @commitlint/cli @commitlint/config-conventional
+
+      - name: Configure commitlint
+        uses: actions/github-script@v7
+        env:
+          ALLOWED_SCOPES: ${{ inputs.allowed_scopes }}
+          ALLOWED_SUBJECT_CASES: ${{ inputs.allowed_subject_cases }}
+        with:
+          script: |-
+            const fs = require('fs');
+            const allowedScopes = process.env.ALLOWED_SCOPES.trim().split(",").filter(n => n).map(n => { return n.trim(); });
+            const allowedSubjectCases = process.env.ALLOWED_SUBJECT_CASES.trim().split(",").filter(n => n).map(n => { return n.trim(); });
+
+            const config = {
+              extends: ["@commitlint/config-conventional"],
+              rules: {
+                'scope-enum': [2, "always", allowedScopes],
+                'subject-case': [2, "always", allowedSubjectCases],
+              }
+            };
+
+            try {
+              fs.writeFileSync("commitlint.config.js", `module.exports = ${JSON.stringify(config)};`);
+            } catch (err) {
+              core.error(`Failed to write commitlint config: ${err}`);
+              core.setFailed(err);
+            }
+
+      - name: Run commitlint on commits
+        if: inputs.lint_commits
+        id: commit-lint
+        run: |
+          commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }}
+
+      - name: Run commitlint on pull request title
+        id: commit-lint-pr-title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "${PR_TITLE}" | commitlint
+
+      - name: Comment on Pull Request on Error
+        if: always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: Converntional Commits Error
+          delete: ${{ steps.commit-lint.conclusion != 'failure' && steps.commit-lint-pr-title.conclusion != 'failure' }}
+          message: |
+            This repository uses conventional commits for versioning. Please ensure commits and PR title follow the specification.
+            Refer to:
+             [Conventional Commits Summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
+
+  release:
+    if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    name: Release Please
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      release_tag: ${{ steps.release.outputs.tag_name }}
+      additional_tags: ${{ steps.additional_tags.outputs.tags }}
+      major_minor_tag: ${{ steps.additional_tags.outputs.major_minor_tag }}
+      major_tag: ${{ steps.additional_tags.outputs.major_tag }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Merge default and user input changelog types
+        uses: actions/github-script@v7
+        id: merge-changelog-types
+        env:
+          CHANGELOG_TYPES: ${{ inputs.changelog_types }}
+        with:
+          script: |-
+            const changelogTypes = [
+              {type: "feat",     section: "Features"},
+              {type: "fix",      section: "Bug Fixes"},
+              {type: "perf",     section: "Performance Improvements"},
+              {type: "deps",     section: "Dependencies"},
+              {type: "revert",   section: "Reverts"},
+              {type: "docs",     section: "Documentation"},
+              {type: "style",    section: "Styles"},
+              {type: "chore",    section: "Miscellaneous Chores"},
+              {type: "refactor", section: "Code Refactoring"},
+              {type: "test",     section: "Tests"},
+              {type: "ci",       section: "Continuous Integration"},
+            ];
+            try {
+              const userTypes = JSON.parse(process.env.CHANGELOG_TYPES.trim());
+              if (Array.isArray(userTypes)) {
+                changelogTypes.push(...userTypes);
+              }
+            } catch (err) {
+              core.warning(`Failed to parse "changelog_types" as JSON: ${err}`);
+            }
+
+            core.setOutput("changelog-types-json", JSON.stringify(changelogTypes));
+
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          default-branch: ${{ github.event.repository.default_branch }}
+          release-type: ${{ inputs.release_type }}
+          package-name: ${{ github.event.repository.name }}
+          changelog-types: ${{ steps.merge-changelog-types.outputs.changelog-types-json }}
+          include-v-in-tag: ${{ inputs.include_v_in_tag }}
+          pull-request-title-pattern: ${{ inputs.pull_request_title_template }}
+          extra-files: ${{ inputs.extra_files }}
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Create additional tags
+        if: steps.release.outputs.release_created
+        id: additional_tags
+        uses: actions/github-script@v7
+        env:
+          MAJOR: ${{ steps.release.outputs.major }}
+          MINOR: ${{ steps.release.outputs.minor }}
+          CREATE_UNQUALIFIED: ${{ inputs.additional_unqualified_tags }}
+          TAG_PREFIX: ${{ inputs.include_v_in_tag && 'v' || '' }}
+          EXTRA_TAGS: ${{ inputs.extra_tags }}
+        with:
+          script: |-
+            const tagPrefix = process.env.TAG_PREFIX;
+            const majorMinorTag = `${tagPrefix}${process.env.MAJOR}.${process.env.MINOR}`;
+            const majorTag = `${tagPrefix}${process.env.MAJOR}`;
+            const createUnqualified = process.env.CREATE_UNQUALIFIED == 'true';
+            const unqalifiedTags = createUnqualified ? [majorMinorTag, majorTag] : []
+
+            const extraTags = process.env.EXTRA_TAGS.split(",").filter(n => n).map(n => { return n.trim(); });
+            const additionalTags = Array.from(new Set([...unqalifiedTags, ...extraTags]));
+
+            const opts = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+            };
+
+            for (const tag of additionalTags) {
+              core.info(`Creating/updating tag ${tag}`);
+              try {
+                try {
+                  // Try to create the tag first
+                  await github.rest.git.createRef({...opts, ref: `refs/tags/${tag}`});
+                } catch (err) {
+                  if (err.response?.data?.message !== 'Reference already exists') {
+                    throw (err);
+                  }
+                  // Try to update the ref if it already exists
+                  await github.rest.git.updateRef({...opts, ref: `tags/${tag}`, force: true});
+                }
+                core.info(`Tag ${tag} created/updated pointing to ${opts.sha}`)
+              } catch (err) {
+                core.error(`Failed to create or update tag ${tag}: ${err} (opts: ${JSON.stringify(opts)})`);
+                core.setFailed(err);
+                process.exit();
+              }
+            }
+
+            core.setOutput("tags", JSON.stringify(additionalTags));
+            if (createUnqualified) {
+              core.setOutput("major_minor_tag", majorMinorTag);
+              core.setOutput("major_tag", majorTag);
+            }

--- a/.github/workflows/pr-scan.yaml
+++ b/.github/workflows/pr-scan.yaml
@@ -1,0 +1,133 @@
+name: Pull Request Scan
+
+on:
+  workflow_call:
+    inputs:
+      fail_on_severity:
+        description: |
+          Threshold for severity level which will trigger pipeline failure.
+          Possible values: low, moderate, high, critical.
+        required: false
+        type: string
+        default: critical
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup
+        shell: bash
+        run: |-
+          # Can't use RUNNER_TEMP because actions/checkout requires the path be inside the workdir
+          SCAN_TEMP=$(mktemp -d scan-temp.XXXXX)
+          echo "SCAN_TEMP=${SCAN_TEMP}" >> ${GITHUB_ENV}
+
+          # install js-yaml and spdx-expression-parse
+          npm i js-yaml spdx-expression-parse
+
+      - name: Checkout Configs
+        uses: actions/checkout@v3
+        with:
+          repository: circlefin/circle-public-github-workflows
+          ref: stable
+          path: ${{ env.SCAN_TEMP }}/scan
+          sparse-checkout: |-
+            config/scan
+
+      - name: Configure dependency review
+        uses: actions/github-script@v7
+        id: config
+        env:
+          SEVERITY: ${{ inputs.fail_on_severity }}
+        with:
+          script: |-
+            const path = require('path');
+            const fs = require('fs');
+            const yaml = require('js-yaml');
+            const spdxParse = require('spdx-expression-parse');
+
+            const configsDir = path.join(process.env.SCAN_TEMP, 'scan', 'config', 'scan');
+
+            if (context.eventName.startsWith("pull_request")) {
+              core.setOutput("is-pr", "true");
+            }
+
+            const validSeverities = ['low', 'moderate', 'high', 'critical'];
+            let severity = process.env.SEVERITY;
+            if (!validSeverities.includes(severity)) {
+              core.warning(`Invalid value for 'fail_on_severity': ${severity}`);
+              severity = 'low';
+            }
+
+            const privateRepo = context.payload?.repository?.private || false;
+
+            let licenseCfgFile = path.join(configsDir, 'license.yaml');
+            try {
+              const licenseCfg = yaml.load(fs.readFileSync(licenseCfgFile));
+              const allowedLicensesRaw = [];
+              allowedLicensesRaw.push(...licenseCfg.license.notice);
+              if (privateRepo) {
+                allowedLicensesRaw.push(...licenseCfg.license.reciprocal);
+              }
+              // Filter out non-SPDX licenses
+              const allowedLicenses = allowedLicensesRaw.filter(l => {
+                try {
+                  spdxParse(l);
+                  return true;
+                } catch (_) {
+                  return false;
+                }
+              });
+
+              let ignoredPackages = [];
+              try {
+                ignoredPackages = fs.readFileSync('.licenseignore').toString('utf-8').split('\n').filter(l => l.startsWith('pkg:'));
+              } catch (err) {
+                core.info(`Failed to read .licenseignore file: ${err}`);
+              }
+
+              let ignoredGhsas = [];
+              try {
+                for ( ghsa of fs.readFileSync('.ghsaignore').toString('utf-8').split('\n').filter(l => l.startsWith('GHSA-')) ){
+                  try {
+                    const ghsaTokens = ghsa.split(/\s+/);
+                    if ( len(ghsaTokens) !== 2 ) {
+                      throw new Error("Must specify GHSA ID and expiration date");
+                    }
+                    const expiration = Date.parse(ghsaTokens[1].replace(/^exp:/,''));
+                    if (expiration > Date.now()) {
+                      ignoredGhsas.push(ghsaTokens[0]);
+                    }
+                  } catch (err) {
+                    core.warning(`Failed to parse line "${ghsa}" in .ghsaignore: ${err}`);
+                  }
+                }
+              } catch (err) {
+                core.info(`Failed to read .ghsasignore file: ${err}`);
+              }
+
+              const depReviewCfg = {
+                'vulnerability-check': true,
+                'fail-on-severity': severity,
+                'license-check': true,
+                'fail-on-scopes': ['runtime', 'development', 'unknown'],
+                'comment-summary-in-pr': 'always',
+                'allow-licenses': allowedLicenses,
+                'allow-dependencies-license': ignoredPackages,
+                'allow-ghsas': ignoredGhsas,
+              }
+              licenseCfgFile = path.join(process.env.RUNNER_TEMP, 'dep-review.yaml');
+              fs.writeFileSync(licenseCfgFile, yaml.dump(depReviewCfg));
+            } catch (err) {
+              core.error(`Failed to generate dependency review config file: ${err}`);
+              core.setFailed(err);
+            }
+            core.setOutput("config-file", licenseCfgFile);
+
+      - name: Pull Request Dependency license check
+        uses: actions/dependency-review-action@v3
+        if: >
+          steps.config.outcome == 'success' &&
+          steps.config.outputs.is-pr == 'true'
+        with:
+          config-file: ${{ steps.config.outputs.config-file }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   © Circle Internet Financial, LTD 2023. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # circle-public-github-workflows
+
+This contains a collection of shared Github Workflows which may be used by pubicly exposed repositories.
+
+## Workflows
+
+This repository contains the following shareable workflows under `.github/workflows`:
+
+* actions-lint - Lints github workflows and actions.
+* attach-release-assets - Attaches SBOM and other build artifacts to releases along with a manifest file.
+* conventional-commit-release - Lints commit messages and PR titles to ensure compliance with [Conventional Commits](https://www.conventionalcommits.org); on default branch builds it will execute the [release-please action](https://github.com/google-github-actions/release-please-action) to generate Github releases & changelogs.
+* pr-scan - Executes the [dependency-review-action](https://github.com/actions/dependency-review-action) to check for vulnerabilities and license compliance in pull request dependencies.

--- a/config/linters/actionlint-matcher.json
+++ b/config/linters/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/config/linters/actionlint.yaml
+++ b/config/linters/actionlint.yaml
@@ -1,0 +1,4 @@
+# Configuration variables in array of strings defined in your repository or
+# organization. `null` means disabling configuration variables check.
+# Empty array means no configuration variable is allowed.
+config-variables: null

--- a/config/scan/license.yaml
+++ b/config/scan/license.yaml
@@ -1,0 +1,320 @@
+scan:
+  scanners:
+    - license
+license:
+  confidencelevel: "0.9"
+  # License classifications are taken from the Circle Open Source Standard
+  # Any license not specifically listed will be classified as `UNKNOWN` vulnerability level
+  unencumbered: []
+  forbidden: []
+  permissive: []
+  # These are not actual licenses, but rather are artifacts of parsing non-standard license strings
+  # contained in POM files.
+  ignored:
+    - "2.0"
+    - With Classpath Exception
+  # Restricted translates to `HIGH` vulnerability level
+  # These licenses are generally unacceptable to use in any context.
+  restricted:
+    - AGPL-1.0 # AGPL 1.0
+    - AGPL-1.0-or-later # AGPL 1.0 or later
+    - AGPL-3.0 # AGPL 3.0
+    - AGPL-3.0-or-later # AGPL 3.0 or later
+    - SSPL-1.0 # Server Side Public License
+    - OSL-1.0 # Open Software License 1.0
+    - OSL-1.1 # Open Software License 1.1
+    - OSL-2.0 # Open Software License 2.0
+    - OSL-2.1 # Open Software License 2.1
+    - OSL-3.0 # Open Software License 3.0
+    - NPOSL-3.0 # Non-Profit Open Software License 3.0
+    - AFL-1.1 # Academic Free License v1.1
+    - AFL-1.2 # Academic Free License v1.2
+    - AFL-2.0 # Academic Free License v2.0
+    - AFL-2.1 # Academic Free License v2.1
+    - AFL-3.0 # Academic Free License v3.0
+    - APSL-1.0 # Apple Public Source License 1.0
+    - APSL-1.1 # Apple Public Source License 1.1
+    - APSL-1.2 # Apple Public Source License 1.2
+    - APSL-2.0 # Apple Public Source License 2.0
+    - RPSL-1.0 # RealNetworks Public Source License v1.0
+    - RPL-1.1 # Reciprocal Public License 1.1
+    - RPL-1.5 # Reciprocal Public License 1.5
+    - Hippocratic-2.1 # Hippocratic License 2.1
+    - Elastic-2.0 # Elastic License 2.0
+    - BUSL-1.1 # Business Source License 1.1
+    - PolyForm-Noncommercial-1.0.0 # PolyForm Noncommercial License 1.0.0
+    - PolyForm-Small-Business-1.0.0 # PolyForm Small Business License 1.0.0
+  # Reciprocal translates to `MEDIUM` vulnerability level
+  # These licenses may be acceptable depending on context.
+  reciprocal:
+    - GPL-2.0 # GNU General Public License v2.0 only
+    - The GNU General Public License (GPL), Version 2 # GNU General Public License v2.0 only
+    - GNU General Public License Version 2 # GNU General Public License v2.0 only
+    - GPL-2.0+ # GNU General Public License v2.0 or later
+    - GPL2 w/ CPE # GNU General Public License v2.0 with classpath exception
+    - GPL-2.0-or-later # GNU General Public License v2.0 or later
+    - GPL-3.0 # GNU General Public License v2.0 only
+    - GPL-3.0+ # GNU General Public License v2.0 or later
+    - GPL-3.0-or-later # GNU General Public License v3.0 or later
+    - LGPL-2.1 # GNU Lesser General Public License v2.1
+    - LGPL-2.1+ # GNU Lesser General Public License v2.1 or later
+    - GNU Lesser General Public License Version 2.1 # GNU Lesser General Public License v2.1
+    - LGPL-2.1-or-later # GNU Lesser General Public License v2.1 or later
+    - LGPL-3.0 # GNU Lesser General Public License v3.0
+    - LGPL-3.0+ # GNU Lesser General Public License v3.0 or later
+    - LGPL-3.0-or-later # GNU Lesser General Public License v3.0 or later
+    - MPL-1.1 # Mozilla Public License 1.1
+    - MPL 1.1 # Mozilla Public License 1.1
+    - MPL-2.0 # Mozilla Public License 2.0
+    - MPL-2.0-no-copyleft-exception # Mozilla Public License 2.0 (no copyleft exception)
+    - CDDL-1.0 # Common Development and Distribution License 1.0
+    - CDDL-1.1 # Common Development and Distribution License 1.1
+    - CDDL + GPLv2 with classpath exception # CDDL and GPL-2 w/claspath exception
+    - CPL-1.0 # Common Public License 1.0
+    - IPL-1.0 # IBM Public License v1.0
+    - EPL-1.0 # Eclipse Public License 1.0
+    - Eclipse Public License - Version 1.0 # Eclipse Public License 1.0
+    - Eclipse Public License - v 1.0 # Eclipse Public License 1.0
+    - EPL-2.0 # Eclipse Public License 2.0
+    - EPL 2.0 # Eclipse Public License 2.0
+    - Eclipse Public License - v 2.0 # Eclipse Public License 2.0
+    - Apache-1.0 # Apache License 1.0
+    - Apache License # Apache License
+    - CC-BY-SA-1.0 # Creative Commons Attribution Share Alike 1.0 Generic
+    - CC-BY-SA-2.0 # Creative Commons Attribution Share Alike 2.0 Generic
+  # Notice translates to `LOW` vulnerability level.
+  # These licenses are generally acceptable to use
+  # This list includes licenses from the [Blue Oak Council](https://blueoakcouncil.org/) list.
+  notice:
+    - BSD-1-Clause # BSD 1-Clause License
+    - BSD-2-Clause # BSD 2-Clause "Simplified" License
+    - BSD 2-Clause # BSD 2-Clause "Simplified" License
+    - BSD-3-Clause # BSD 3-Clause "New" or "Revised" License
+    - The BSD 3-Clause License # BSD 3-Clause "New" or "Revised" License
+    - The New BSD License # BSD 3-Clause "New" or "Revised" License
+    - Modified BSD # BSD 3-Clause "New" or "Revised" License (String used in https://github.com/eclipse-ee4j/jersey/blob/2.x/core-server/pom.xml to describe https://asm.ow2.io/license.html)
+    - Revised BSD # BSD 3-Clause "New" or "Revised" License
+    - MIT # MIT License
+    - MIT License # MIT License
+    - MIT license # MIT License
+    - The MIT License # MIT License
+    - The MIT License (MIT) # MIT License
+    - MIT-0 # MIT No Attribution
+    - Apache-1.1 # Apache License 1.1
+    - Apache Software License, Version 1.1 # Apache License 1.1
+    - Apache-2.0 # Apache License 2.0
+    - Apache License 2.0 # Apache License 2.0
+    - The Apache License, Version 2.0 # Apache License 2.0
+    - Apache License, Version 2.0 # Apache License 2.0
+    - Apache License, version 2.0 # Apache License 2.0
+    - The Apache Software License, Version 2.0 # Apache License 2.0
+    - Apache Software License - Version 2.0 # Apache License 2.0
+    - Artistic-1.0 # Artistic License 1.0
+    - Artistic-2.0 # Artistic License 2.0
+    - PHP-3.0 # PHP License v3.0
+    - PHP-3.01 # PHP License v3.01
+    - PSF-2.0 # Python Software Foundation License 2.0
+    - Zlib # zlib License
+    - zlib-acknowledgement # zlib/libpng License with Acknowledgement
+    - BSL-1.0 # Boost Software License 1.0
+    - OpenSSL # OpenSSL License
+    - WTFPL # Do What The F*ck You Want To Public License
+    - CC0-1.0 # Creative Commons Zero v1.0 Universal
+    - CC-PDDC # Creative Commons Public Domain Dedication and Certification
+    - CC-BY-1.0 # Creative Commons Attribution 1.0 Generic
+    - CC-BY-2.0 # Creative Commons Attribution 2.0 Generic
+    - CC-BY-2.5 # Creative Commons Attribution 2.5 Generic
+    - CC-BY-3.0 # Creative Commons Attribution 3.0 Unported
+    - CC-BY-4.0 # Creative Commons Attribution 4.0 International
+    - Unlicense # The Unlicense
+    - ISC # ISC License
+    # Blue Oak "Model" licenses
+    - BlueOak-1.0.0 # Blue Oak Model License 1.0.0
+    # Blue Oak "Gold" licenses
+    - BSD-2-Clause-Patent # BSD-2-Clause Plus Patent License
+    # Blue Oak "Silver" licenses
+    - ADSL # Amazon Digital Services License
+    - Apache-2.0 # Apache License 2.0
+    - APAFML # Adobe Postscript AFM License
+    - BSD-1-Clause # BSD 1-Clause License
+    - BSD-2-Clause # BSD 2-Clause "Simplified" License
+    - BSD-2-Clause-FreeBSD # BSD 2-Clause FreeBSD License
+    - BSD-2-Clause-NetBSD # BSD 2-Clause NetBSD License
+    - BSD-2-Clause-Views # BSD 2-Clause with Views Sentence
+    - BSL-1.0 # Boost Software License 1.0
+    - DSDP # DSDP License
+    - ECL-1.0 # Educational Community License v1.0
+    - ECL-2.0 # Educational Community License v2.0
+    - ImageMagick # ImageMagick License
+    - ISC # ISC License
+    - Linux-OpenIB # Linux Kernel Variant of OpenIB.org license
+    - MIT # MIT License
+    - MIT-Modern-Variant # MIT License Modern Variant
+    - MS-PL # Microsoft Public License
+    - MulanPSL-1.0 # Mulan Permissive Software License, Version 1
+    - Mup # Mup License
+    - PostgreSQL # PostgreSQL License
+    - Spencer-99 # Spencer License 99
+    - UPL-1.0 # Universal Permissive License v1.0
+    - Xerox # Xerox License
+    # Blue Oak "Bronze" licenses
+    - 0BSD # BSD Zero Clause License
+    - AFL-1.1 # Academic Free License v1.1
+    - AFL-1.2 # Academic Free License v1.2
+    - AFL-2.0 # Academic Free License v2.0
+    - AFL-2.1 # Academic Free License v2.1
+    - AFL-3.0 # Academic Free License v3.0
+    - AMDPLPA # AMD's plpa_map.c License
+    - AML # Apple MIT License
+    - AMPAS # Academy of Motion Picture Arts and Sciences BSD
+    - ANTLR-PD # ANTLR Software Rights Notice
+    - ANTLR-PD-fallback # ANTLR Software Rights Notice with license fallback
+    - Apache-1.0 # Apache License 1.0
+    - Apache-1.1 # Apache License 1.1
+    - Artistic-2.0 # Artistic License 2.0
+    - Bahyph # Bahyph License
+    - Barr # Barr License
+    - BSD-3-Clause # BSD 3-Clause "New" or "Revised" License
+    - BSD-3-Clause-Attribution # BSD with attribution
+    - BSD-3-Clause-Clear # BSD 3-Clause Clear License
+    - BSD-3-Clause-LBNL # Lawrence Berkeley National Labs BSD variant license
+    - BSD-3-Clause-Modification # BSD 3-Clause Modification
+    - BSD-3-Clause-No-Nuclear-License-2014 # BSD 3-Clause No Nuclear License 2014
+    - BSD-3-Clause-No-Nuclear-Warranty # BSD 3-Clause No Nuclear Warranty
+    - BSD-3-Clause-Open-MPI # BSD 3-Clause Open MPI Variant
+    - BSD-4-Clause # BSD 4-Clause "Original" or "Old" License
+    - BSD-4-Clause-Shortened # BSD 4-Clause Shortened
+    - BSD-4-Clause-UC # BSD-4-Clause (University of California-Specific)
+    - BSD-Source-Code # BSD Source Code Attribution
+    - bzip2-1.0.5 # bzip2 and libbzip2 License v1.0.5
+    - bzip2-1.0.6 # bzip2 and libbzip2 License v1.0.6
+    - CC0-1.0 # Creative Commons Zero v1.0 Universal
+    - CNRI-Jython # CNRI Jython License
+    - CNRI-Python # CNRI Python License
+    - CNRI-Python-GPL-Compatible # CNRI Python Open Source GPL Compatible License Agreement
+    - Cube # Cube License
+    - curl # curl License
+    - eGenix # eGenix.com Public License 1.1.0
+    - Entessa # Entessa Public License v1.0
+    - FTL # Freetype Project License
+    - HTMLTIDY # HTML Tidy License
+    - IBM-pibs # IBM PowerPC Initialization and Boot Software
+    - ICU # ICU License
+    - Info-ZIP # Info-ZIP License
+    - Intel # Intel Open Source License
+    - JasPer-2.0 # JasPer License
+    - Libpng # libpng License
+    - libpng-2.0 # PNG Reference Library version 2
+    - libtiff # libtiff License
+    - LPPL-1.3c # LaTeX Project Public License v1.3c
+    - MIT-0 # MIT No Attribution
+    - MIT-advertising # Enlightenment License (e16)
+    - MIT-open-group # MIT Open Group Variant
+    - MIT-CMU # CMU License
+    - MIT-enna # enna License
+    - MIT-feh # feh License
+    - MITNFA # MIT +no-false-attribs license
+    - MTLL # Matrix Template Library License
+    - MulanPSL-2.0 # Mulan Permissive Software License, Version 2
+    - Multics # Multics License
+    - Naumen # Naumen Public License
+    - NCSA # University of Illinois/NCSA Open Source License
+    - Net-SNMP # Net-SNMP License
+    - NetCDF # NetCDF license
+    - NTP # NTP License
+    - OLDAP-2.0 # Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)
+    - OLDAP-2.0.1 # Open LDAP Public License v2.0.1
+    - OLDAP-2.1 # Open LDAP Public License v2.1
+    - OLDAP-2.2 # Open LDAP Public License v2.2
+    - OLDAP-2.2.1 # Open LDAP Public License v2.2.1
+    - OLDAP-2.2.2 # Open LDAP Public License 2.2.2
+    - OLDAP-2.3 # Open LDAP Public License v2.3
+    - OLDAP-2.4 # Open LDAP Public License v2.4
+    - OLDAP-2.5 # Open LDAP Public License v2.5
+    - OLDAP-2.6 # Open LDAP Public License v2.6
+    - OLDAP-2.7 # Open LDAP Public License v2.7
+    - OLDAP-2.8 # Open LDAP Public License v2.8
+    - OML # Open Market License
+    - OpenSSL # OpenSSL License
+    - PHP-3.0 # PHP License v3.0
+    - PHP-3.01 # PHP License v3.01
+    - Plexus # Plexus Classworlds License
+    - PSF-2.0 # Python Software Foundation License 2.0
+    - Python-2.0 # Python License 2.0
+    - Ruby # Ruby License
+    - Saxpath # Saxpath License
+    - SGI-B-2.0 # SGI Free Software License B v2.0
+    - SMLNJ # Standard ML of New Jersey License
+    - SWL # Scheme Widget Library (SWL) Software License Agreement
+    - TCL # TCL/TK License
+    - TCP-wrappers # TCP Wrappers License
+    - Unicode-DFS-2015 # Unicode License Agreement - Data Files and Software (2015)
+    - Unicode-DFS-2016 # Unicode License Agreement - Data Files and Software (2016)
+    - Unlicense # The Unlicense
+    - VSL-1.0 # Vovida Software License v1.0
+    - W3C # W3C Software Notice and License (2002-12-31)
+    - X11 # X11 License
+    - XFree86-1.1 # XFree86 License 1.1
+    - Xnet # X.Net License
+    - xpp # XPP License
+    - Zlib # zlib License
+    - zlib-acknowledgement # zlib/libpng License with Acknowledgement
+    - ZPL-2.0 # Zope Public License 2.0
+    - ZPL-2.1 # Zope Public License 2.1
+    # Blue Oak "Lead" licenses
+    - AAL # Attribution Assurance License
+    - Adobe-2006 # Adobe Systems Incorporated Source Code License Agreement
+    - Afmparse # Afmparse License
+    - Artistic-1.0 # Artistic License 1.0
+    - Artistic-1.0-cl8 # Artistic License 1.0 w/clause 8
+    - Artistic-1.0-Perl # Artistic License 1.0 (Perl)
+    - Beerware # Beerware License
+    - blessing # SQLite Blessing
+    - Borceux # Borceux license
+    - CECILL-B # CeCILL-B Free Software License Agreement
+    - ClArtistic # Clarified Artistic License
+    - Condor-1.1 # Condor Public License v1.1
+    - Crossword # Crossword License
+    - CrystalStacker # CrystalStacker License
+    - diffmark # diffmark license
+    - DOC # DOC License
+    - EFL-1.0 # Eiffel Forum License v1.0
+    - EFL-2.0 # Eiffel Forum License v2.0
+    - Fair # Fair License
+    - FSFUL # FSF Unlimited License
+    - FSFULLR # FSF Unlimited License (with License Retention)
+    - Giftware # Giftware License
+    - HPND # Historical Permission Notice and Disclaimer
+    - IJG # Independent JPEG Group License
+    - Leptonica # Leptonica License
+    - LPL-1.0 # Lucent Public License Version 1.0
+    - LPL-1.02 # Lucent Public License v1.02
+    - MirOS # MirOS License
+    - mpich2 # mpich2 License
+    - NASA-1.3 # NASA Open Source Agreement 1.3
+    - NBPL-1.0 # Net Boolean Public License v1
+    - Newsletr # Newsletr License
+    - NLPL # No Limit Public License
+    - NRL # NRL License
+    - OGTSL # Open Group Test Suite License
+    - OLDAP-1.1 # Open LDAP Public License v1.1
+    - OLDAP-1.2 # Open LDAP Public License v1.2
+    - OLDAP-1.3 # Open LDAP Public License v1.3
+    - OLDAP-1.4 # Open LDAP Public License v1.4
+    - psutils # psutils License
+    - Qhull # Qhull License
+    - Rdisc # Rdisc License
+    - RSA-MD # RSA Message-Digest License
+    - Spencer-86 # Spencer License 86
+    - Spencer-94 # Spencer License 94
+    - TU-Berlin-1.0 # Technische Universitaet Berlin License 1.0
+    - TU-Berlin-2.0 # Technische Universitaet Berlin License 2.0
+    - Vim # Vim License
+    - W3C-19980720 # W3C Software Notice and License (1998-07-20)
+    - W3C-20150513 # W3C Software Notice and Document License (2015-05-13)
+    - Wsuipa # Wsuipa License
+    - WTFPL # Do What The F*ck You Want To Public License
+    - xinetd # xinetd License
+    - Zed # Zed License
+    - Zend-2.0 # Zend License v2.0
+    - ZPL-1.1 # Zope Public License 1.1


### PR DESCRIPTION
Add initial workflows:

* actions-lint - Lints github workflows and actions.
* attach-release-assets - Attaches SBOM and other build artifacts to releases along with a manifest file.
* conventional-commit-release - Lints commit messages and PR titles to ensure compliance with [Conventional Commits](https://www.conventionalcommits.org); on default branch builds it will execute the [release-please action](https://github.com/google-github-actions/release-please-action) to generate Github releases & changelogs.
* pr-scan - Executes the [dependency-review-action](https://github.com/actions/dependency-review-action) to check for vulnerabilities and license compliance in pull request dependencies.

This also adds a CI pipeline for this repository which dogfoods the workflows. The PR checks are disabled for now as they require checking out a tag of this repo which will only exist after the initial release.