### PR TITLE
feat(scan): add input to specify runner for pr-scan

### DIFF
--- a/.github/workflows/pr-scan.yaml
+++ b/.github/workflows/pr-scan.yaml
@@ -26,10 +26,16 @@ on:
         required: false
         type: string
         default: critical
+      runs-on:
+        description: |
+          Github runner on which this workflow should run.
+        required: false
+        type: string
+        default: ubuntu-latest
 
 jobs:
   scan:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Setup
         shell: bash


### PR DESCRIPTION
Adds an input to the `scan-pr` workflow to allow overriding the runner type