### PR TITLE
fix: fixes for repo scan and commitlint

### DIFF
--- a/.github/workflows/conventional-commit-release.yaml
+++ b/.github/workflows/conventional-commit-release.yaml
@@ -117,13 +117,13 @@ jobs:
         if: steps.checkout.conclusion == 'success'
         run: git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14.x
+          node-version: 20.x
 
       - name: Install commitlint
         run: |
-          npm install -g @commitlint/cli @commitlint/config-conventional
+          npm install -g @commitlint/{cli,config-conventional}@^18.6.0
 
       - name: Configure commitlint
         uses: actions/github-script@v7

--- a/.github/workflows/pr-scan.yaml
+++ b/.github/workflows/pr-scan.yaml
@@ -47,8 +47,13 @@ jobs:
           # install js-yaml and spdx-expression-parse
           npm i js-yaml spdx-expression-parse
 
+      - name: Checkout Source
+        uses: actions/checkout@v4
+        with:
+          path: ${{ env.SCAN_TEMP }}/src
+
       - name: Checkout Configs
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: circlefin/circle-public-github-workflows
           ref: stable
@@ -69,6 +74,7 @@ jobs:
             const spdxParse = require('spdx-expression-parse');
 
             const configsDir = path.join(process.env.SCAN_TEMP, 'scan', 'config', 'scan');
+            const srcDir = path.join(process.env.SCAN_TEMP, 'src');
 
             if (context.eventName.startsWith("pull_request")) {
               core.setOutput("is-pr", "true");
@@ -102,15 +108,17 @@ jobs:
               });
 
               let ignoredPackages = [];
+              const licenseIgnoreFile = path.join(srcDir, '.licenseignore');
               try {
-                ignoredPackages = fs.readFileSync('.licenseignore').toString('utf-8').split('\n').filter(l => l.startsWith('pkg:'));
+                ignoredPackages = fs.readFileSync(licenseIgnoreFile).toString('utf-8').split('\n').filter(l => l.startsWith('pkg:'));
               } catch (err) {
                 core.info(`Failed to read .licenseignore file: ${err}`);
               }
 
               let ignoredGhsas = [];
+              const ghsaIgnoreFile = path.join(srcDir, '.ghsaignore');
               try {
-                for ( ghsa of fs.readFileSync('.ghsaignore').toString('utf-8').split('\n').filter(l => l.startsWith('GHSA-')) ){
+                for ( ghsa of fs.readFileSync(ghsaIgnoreFile).toString('utf-8').split('\n').filter(l => l.startsWith('GHSA-')) ){
                   try {
                     const ghsaTokens = ghsa.split(/\s+/);
                     if ( len(ghsaTokens) !== 2 ) {
@@ -135,11 +143,13 @@ jobs:
                 'fail-on-scopes': ['runtime', 'development', 'unknown'],
                 'comment-summary-in-pr': 'always',
                 'allow-licenses': allowedLicenses,
-                'allow-dependencies-license': ignoredPackages,
+                'allow-dependencies-licenses': ignoredPackages,
                 'allow-ghsas': ignoredGhsas,
               }
               licenseCfgFile = path.join(process.env.RUNNER_TEMP, 'dep-review.yaml');
-              fs.writeFileSync(licenseCfgFile, yaml.dump(depReviewCfg));
+              const yamlConfig = yaml.dump(depReviewCfg);
+              core.debug(yamlConfig);
+              fs.writeFileSync(licenseCfgFile, yamlConfig);
             } catch (err) {
               core.error(`Failed to generate dependency review config file: ${err}`);
               core.setFailed(err);


### PR DESCRIPTION
This fixes some issues with the pr-scan and conventional-commit-release workflows:

## pr-scan
* Need to check out the source repo in order to read the contents of `.licenseignore` and `.ghsaignore`.
* Typo in config key for `allow-dependencies-licenses`.
* Upgrade checkout action to `v4`.
* Debug log the config file.

## conventional-commit-release
* Pin commitlint to `18.6.0` as there are some incompatible changes in later versions.
* Use node 20.