### PR TITLE
feat(release): sign commits created by release actor

### DIFF
--- a/.github/workflows/conventional-commit-release.yaml
+++ b/.github/workflows/conventional-commit-release.yaml
@@ -88,7 +88,13 @@ on:
         value: ${{ jobs.release.outputs.major_tag }}
     secrets:
       RELEASE_TOKEN:
-        description: Github PAT used for executing the release-please action. Only required for default branch builds.
+        description: Github PAT used for executing the release-please action. Only required on push events to the default branch.
+        required: false
+      RELEASE_ACTOR_GPG_PRIVATE_KEY:
+        description: GPG Private key associated with the release actor. Used to ensure that commits are signed. Only required on push events to the default branch.
+        required: false
+      RELEASE_ACTOR_GPG_PASSPHRASE:
+        description: Passphrase to unlock the use the GPG Key passed in `RELEASE_ACTOR_GPG_PRIVATE_KEY`. Used to ensure that commits are signed. Only required on push events to the default branch.
         required: false
 
 permissions:
@@ -230,6 +236,34 @@ jobs:
           pull-request-title-pattern: ${{ inputs.pull_request_title_template }}
           extra-files: ${{ inputs.extra_files }}
           token: ${{ secrets.RELEASE_TOKEN }}
+
+
+      - name: Checkout Release Branch
+        if: ${{ steps.release.outputs.pr != '' }}
+        id: checkout-release-branch
+        uses: actions/checkout@v4.1.1
+        with:
+          ref: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
+          fetch-depth: 0
+
+      - name: Import GPG key
+        id: key-import
+        if: ${{ steps.checkout-release-branch.conclusion == 'success' }}
+        uses: crazy-max/ghaction-import-gpg@v6.1.0
+        with:
+          gpg_private_key: ${{ secrets.RELEASE_ACTOR_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.RELEASE_ACTOR_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Amend the PR commit to sign it
+        if: ${{ steps.key-import.conclusion == 'success' }}
+        run: |-
+          git config --global user.name "${{ steps.key-import.outputs.name }}"
+          git config --global user.email "${{ steps.key-import.outputs.email }}"
+          git commit --amend --no-edit -S
+          git push --force
 
       - name: Create additional tags
         if: steps.release.outputs.release_created


### PR DESCRIPTION
## Summary
To ensure that commits aren't unsigned, or unverified when vigilant mode is enabled - we need to ensure that the commit associated with a release is signed by a GPG key associated with the release actor.
ie.
<img width="850" alt="image" src="https://github.com/user-attachments/assets/7a10150a-a5c3-4efe-ae04-a8c17a6625ec">

Release please unfortunately still does not support signing commits with a gpg key directly - per issue https://github.com/googleapis/release-please/issues/1314
However, we can checking the branch and use this to ensure the commits are signed.

After signing introducing this change - we get verified commits
<img width="849" alt="image" src="https://github.com/user-attachments/assets/0faf2c99-fbf1-4a2b-93ff-456b8729ab20">

