### PR TITLE
fix: conventional commit release secrets

### DIFF
--- a/.github/workflows/circle-public-workflows-pipeline.yaml
+++ b/.github/workflows/circle-public-workflows-pipeline.yaml
@@ -38,7 +38,9 @@ jobs:
       additional_unqualified_tags: true
       extra_tags: stable
     secrets:
-      RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TOKEN: ${{ secrets.PUBLIC_RELEASES_TOKEN }}
+      RELEASE_ACTOR_GPG_PRIVATE_KEY: ${{ secrets.PUBLIC_RELEASES_GPG_PRIVATE_KEY }}
+      RELEASE_ACTOR_GPG_PASSPHRASE: ${{ secrets.PUBLIC_RELEASES_GPG_PASSPHRASE }}
 
   attach-assets:
     uses: ./.github/workflows/attach-release-assets.yaml


### PR DESCRIPTION
## Summary

Updating the conventional commit release secrets which are used, due to recent disabling of organization setting used to allow pull request creation (and approval) via the automatic GITHUB_ACTIONS tokens.

This follows on from the setup in https://github.com/circlefin/circle-public-github-workflows/pull/16 which adds some extra support for gpg signing the release branch commits. 

This will setup @circle-bot-releases as the actor for creating release prs and publishing releases.