### PR TITLE
fix(release): ensure release actor pushes gpg-signed commit

### DIFF
--- a/.github/workflows/conventional-commit-release.yaml
+++ b/.github/workflows/conventional-commit-release.yaml
@@ -244,6 +244,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           ref: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
+          token: ${{ secrets.RELEASE_TOKEN }}
           fetch-depth: 0
 
       - name: Import GPG key


### PR DESCRIPTION
## Summary
The amended commit of a release, containing the gpg verified commit is pushed by github-actions currently. This results in subsequent actions not be triggered.
To ensure this works as expected, switching the checkout to use the release actors token to checkout.