### PR TITLE
chore: Use fork of dependency review action

### DIFF
--- a/.github/workflows/pr-scan.yaml
+++ b/.github/workflows/pr-scan.yaml
@@ -166,7 +166,7 @@ jobs:
             core.setOutput("config-file", licenseCfgFile);
 
       - name: Pull Request Dependency license check
-        uses: actions/dependency-review-action@v4
+        uses: circlefin/dependency-review-action@1bfb5f6f409079628491f1c22b1d92cba62cffbf
         if: >
           steps.config.outcome == 'success' &&
           steps.config.outputs.is-pr == 'true'


### PR DESCRIPTION
The upstream depenendency-review-action uses the change's `package_url` (as returned from the dependency graph API) to match against the exclusions passed via `allow-dependencies-licenses`. However, some changes do not include `package_url`, but they can still result in the action failing a license check as the check itself doesn't rely on `package_url`. Currently there's no mechanism in place to exclude a dependency from the license check if the package_url is empty.

I created a fork of the action and added a [fallback mechanism](https://github.com/circlefin/dependency-review-action/commit/1bfb5f6f409079628491f1c22b1d92cba62cffbf) that parses `source_repository_url` to attempt to match based on the repository name using the `github` PURL type. So `allow-dependencies-licenses` could include, for example, `pkg:github/owner/repo` and that would match a change with `source_repository_url: "https://github.com/owner/repo"`. 

This doesn't cover all cases; if `source_repository_url` is empty or doesn't point to a github-hosted repository then it will still fail to match, but this should cover a good number of cases.