### PR TITLE
chore: support passing fingerprint to crazy-max/gh-action-import-gpg

### DIFF
--- a/.github/workflows/conventional-commit-release.yaml
+++ b/.github/workflows/conventional-commit-release.yaml
@@ -96,6 +96,9 @@ on:
       RELEASE_ACTOR_GPG_PASSPHRASE:
         description: Passphrase to unlock the use the GPG Key passed in `RELEASE_ACTOR_GPG_PRIVATE_KEY`. Used to ensure that commits are signed. Only required on push events to the default branch.
         required: false
+      RELEASE_ACTOR_GPG_KEY_FINGERPRINT:
+        description: Fingerprint of the GPG Key associated with the release actor. Used to ensure that when using OpenPGP Subkeys for signing, we don't encounter https://github.com/crazy-max/ghaction-import-gpg/issues/146
+        required: false
 
 permissions:
   contents: write
@@ -254,6 +257,7 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.RELEASE_ACTOR_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.RELEASE_ACTOR_GPG_PASSPHRASE }}
+          fingerprint: ${{ secrets.RELEASE_ACTOR_GPG_KEY_FINGERPRINT }}
           git_config_global: true
           git_user_signingkey: true
           git_commit_gpgsign: true


### PR DESCRIPTION
Recently encountered the following error, whilst adopting gpg subkeys.
```
::group::Getting keygrips
Getting keygrips
  Presetting passphrase for 550E60BC0F9E1F21B8717DFDEC6D321E74CC7B19
  ::endgroup::
Error: ERR 67108891 Not found <GPG Agent>
```

This is related to https://github.com/crazy-max/ghaction-import-gpg/issues/146

Setting up this reusable workflow to propagation an optional secret bearing the fingerprint down to the action.