### PR TITLE
fix: add comment-summary-in-pr parameter

### DIFF
--- a/.github/workflows/pr-scan.yaml
+++ b/.github/workflows/pr-scan.yaml
@@ -39,6 +39,10 @@ on:
         required: false
         type: boolean
         default: true
+      comment-summary-in-pr:
+        description: Determines if the summary is posted as a comment in the PR itself. Setting this to `always` or `on-failure` requires you to give the workflow the write permissions for pull-requests
+        type: string
+        default: always
 
 jobs:
   scan:
@@ -150,7 +154,7 @@ jobs:
                 'fail-on-severity': severity,
                 'license-check': true,
                 'fail-on-scopes': ['runtime', 'development', 'unknown'],
-                'comment-summary-in-pr': 'always',
+                'comment-summary-in-pr': ${{ inputs.comment-summary-in-pr }}
                 'allow-licenses': allowedLicenses,
                 'allow-dependencies-licenses': ignoredPackages,
                 'allow-ghsas': ignoredGhsas,


### PR DESCRIPTION

Having the following [error](https://github.com/circlefin/payments-sample-app/actions/runs/17279189766/job/49043664482?pr=405) in payments-sample-app:
```
Error: $GITHUB_STEP_SUMMARY upload aborted, supports content up to a size of 1024k, got 1476k. For more information see: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-markdown-summary
```

Adding a toggle to remove the pr summary.