### PR TITLE
chore(stepsecurity): update workflows to use custom hosted runners with built-in StepSecurity

### DIFF
--- a/.github/workflows/actions-lint.yaml
+++ b/.github/workflows/actions-lint.yaml
@@ -21,17 +21,9 @@ on:
 
 jobs:
   lint_validate_actions:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
+    runs-on: github-hosted-small
 
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
-        with:
-          egress-policy: block
-          policy: global-allowed-endpoints-policy
-
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Checkout Actoinlint Configs

--- a/.github/workflows/attach-release-assets.yaml
+++ b/.github/workflows/attach-release-assets.yaml
@@ -62,18 +62,10 @@ permissions:
 
 jobs:
   release_attach_assets:
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
     if: github.event_name == 'push' && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
-    permissions:
-      id-token: write
 
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
-        with:
-          egress-policy: block
-          policy: global-allowed-endpoints-policy
-
       - name: Download all build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         if: inputs.artifact_file_globs != ''

--- a/.github/workflows/conventional-commit-release.yaml
+++ b/.github/workflows/conventional-commit-release.yaml
@@ -108,17 +108,9 @@ jobs:
   commit-lint:
     name: PR Title and Commits Lint
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
+    runs-on: github-hosted-small
 
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
-        with:
-          egress-policy: block
-          policy: global-allowed-endpoints-policy
-
       - name: Calculate Fetch Depth
         if: inputs.lint_commits
         id: fetch-depth
@@ -196,23 +188,15 @@ jobs:
   release:
     if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     name: Release Please
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       release_tag: ${{ steps.release.outputs.tag_name }}
       additional_tags: ${{ steps.additional_tags.outputs.tags }}
       major_minor_tag: ${{ steps.additional_tags.outputs.major_minor_tag }}
       major_tag: ${{ steps.additional_tags.outputs.major_tag }}
-    permissions:
-      id-token: write
 
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
-        with:
-          egress-policy: block
-          policy: global-allowed-endpoints-policy
-
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Merge default and user input changelog types

--- a/.github/workflows/pr-scan.yaml
+++ b/.github/workflows/pr-scan.yaml
@@ -43,16 +43,8 @@ on:
 jobs:
   scan:
     runs-on: ${{ inputs.runs-on }}
-    permissions:
-      id-token: write
 
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
-        with:
-          egress-policy: block
-          policy: global-allowed-endpoints-policy
-
       - name: Setup
         shell: bash
         run: |-


### PR DESCRIPTION
## Summary
This PR updates GitHub Actions workflows to use custom hosted runners that have StepSecurity built-in, removing the need for the explicit StepSecurity harden-runner action.

## What Changed
- Removed step-security/harden-runner action steps (no longer needed as StepSecurity is built into custom runners)
- Removed id-token: write permissions (no longer needed without the StepSecurity action)
- Updated runs-on from ubuntu-latest to github-hosted-small (custom runners with built-in StepSecurity)
- Converted non-circlefin action versions to commit SHAs with version comments for security pinning (e.g., actions/checkout@abc123 # v3.6.0)
- circlefin GitHub actions remain unchanged

## Purpose
Our custom hosted runners (github-hosted-small) now have StepSecurity built-in at the runner level, so we no longer need to add it as an explicit step in each workflow. This simplifies our workflows while maintaining the same security posture.

## Testing
- All workflow syntax changes have been validated
- No functional changes to workflow behavior
- StepSecurity protection is maintained via the custom runners
- Review the diff to ensure only intended changes occurred