### PR TITLE
chore(ci): bump github actions to node 24

### DIFF
--- a/.github/workflows/actions-lint.yaml
+++ b/.github/workflows/actions-lint.yaml
@@ -32,10 +32,10 @@ jobs:
           egress-policy: block
           policy: global-allowed-endpoints-policy
 
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Checkout Actoinlint Configs
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: circlefin/circle-public-github-workflows
           ref: stable

--- a/.github/workflows/attach-release-assets.yaml
+++ b/.github/workflows/attach-release-assets.yaml
@@ -75,7 +75,7 @@ jobs:
           policy: global-allowed-endpoints-policy
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: inputs.artifact_file_globs != ''
         id: download-artifacts
         with:
@@ -98,7 +98,7 @@ jobs:
           echo "tag=${TAG}" >> ${GITHUB_OUTPUT}
 
       - name: Generate SBOM from Dependency Graph
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         if: inputs.generate_sbom
         env:
           RELEASE_TAG: ${{ steps.setup.outputs.tag }}
@@ -155,7 +155,7 @@ jobs:
           sha256sum * | tee ${MANIFEST_FILENAME}
 
       - name: Attach assets to release
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RELEASE_TAG: ${{ steps.setup.outputs.tag }}
         with:

--- a/.github/workflows/conventional-commit-release.yaml
+++ b/.github/workflows/conventional-commit-release.yaml
@@ -127,7 +127,7 @@ jobs:
       - name: Checkout repo
         if: steps.fetch-depth.conclusion == 'success'
         id: checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: ${{ steps.fetch-depth.outputs.depth }}
 
@@ -135,7 +135,7 @@ jobs:
         if: steps.checkout.conclusion == 'success'
         run: git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.x
 
@@ -144,7 +144,7 @@ jobs:
           npm install -g @commitlint/{cli,config-conventional}@^18.6.0
 
       - name: Configure commitlint
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ALLOWED_SCOPES: ${{ inputs.allowed_scopes }}
           ALLOWED_SUBJECT_CASES: ${{ inputs.allowed_subject_cases }}
@@ -213,10 +213,10 @@ jobs:
           egress-policy: block
           policy: global-allowed-endpoints-policy
 
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Merge default and user input changelog types
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: merge-changelog-types
         env:
           CHANGELOG_TYPES: ${{ inputs.changelog_types }}
@@ -262,7 +262,7 @@ jobs:
       - name: Checkout Release Branch
         if: ${{ steps.release.outputs.pr != '' }}
         id: checkout-release-branch
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -271,7 +271,7 @@ jobs:
       - name: Import GPG key
         id: key-import
         if: ${{ steps.checkout-release-branch.conclusion == 'success' }}
-        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.RELEASE_ACTOR_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.RELEASE_ACTOR_GPG_PASSPHRASE }}
@@ -291,7 +291,7 @@ jobs:
       - name: Create additional tags
         if: steps.release.outputs.release_created
         id: additional_tags
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           MAJOR: ${{ steps.release.outputs.major }}
           MINOR: ${{ steps.release.outputs.minor }}

--- a/.github/workflows/pr-scan.yaml
+++ b/.github/workflows/pr-scan.yaml
@@ -64,12 +64,12 @@ jobs:
           npm i js-yaml spdx-expression-parse
 
       - name: Checkout Source
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: ${{ env.SCAN_TEMP }}/src
 
       - name: Checkout Configs
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: circlefin/circle-public-github-workflows
           ref: stable
@@ -78,7 +78,7 @@ jobs:
             config/scan
 
       - name: Configure dependency review
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: config
         env:
           SEVERITY: ${{ inputs.fail_on_severity }}


### PR DESCRIPTION
## Summary

SHA-pin update of every third-party GitHub Action used in this repo's shared workflows to its first Node-24-compatible release. Pre-emptive migration ahead of GitHub Actions runner Node 20 removal in Fall 2026.

Because this is the shared-workflows repo, downstream consumers (every repo that calls `circlefin/circle-public-github-workflows/.github/workflows/<X>@v1`) will pick up the new pins automatically when the `v1` floating tag advances after merge.

## Actions bumped (5 unique, 16 pins)

| Action | Old tag | New SHA → tag |
|---|---|---|
| `actions/checkout` | v4 | `df4cb1c0…` (v6.0.3) |
| `actions/download-artifact` | v4.3.0 | `3e5f45b2…` (v8.0.1) |
| `actions/github-script` | v7.1.0 | `3a2844b7…` (v9.0.0) |
| `actions/setup-node` | v4.x | `48b55a01…` (v6.4.0) |
| `crazy-max/ghaction-import-gpg` | v6.x | `2dc316de…` (v7.0.0) |

## Files touched (4)

- `.github/workflows/actions-lint.yaml` (2 pins)
- `.github/workflows/attach-release-assets.yaml` (3 pins)
- `.github/workflows/conventional-commit-release.yaml` (8 pins)
- `.github/workflows/pr-scan.yaml` (3 pins)

## Verification

Every emitted SHA was verified via `gh api /repos/<owner>/<repo>/commits/<sha>` before commit.

## Test coverage

Three of the four modified workflows are **self-exercised by this PR's own CI** via the existing pipeline orchestrator (`circle-public-workflows-pipeline.yaml`):

| Workflow | How it's exercised on PR |
|---|---|
| `actions-lint.yaml` | The `lint-actions` job in the pipeline calls it on every PR. If `actions/checkout@v6.0.3` regresses, this job fails. |
| `pr-scan.yaml` | The `pr-scan` job in the pipeline calls it on every PR. Exercises `actions/checkout` + `actions/github-script` bumps end-to-end. |
| `conventional-commit-release.yaml` | The `conventional-commit-release` job in the pipeline calls it on every PR. Internal release-creation steps are gated on `push` so nothing is actually published — but the action-resolution + checkout + setup-node + github-script paths all execute. |

### Declared exception

- `attach-release-assets.yaml` — the workflow's `release_attach_assets` job is hardcoded with `if: github.event_name == 'push' && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref`. On a PR event, the whole job is skipped. Adding a synthetic test job would require modifying the workflow's gating logic to accept a test-mode override input — invasive for a pure SHA-bump change. The 3 pins in this file (`actions/download-artifact@v8.0.1` and 2× `actions/github-script@v9.0.0`) will be exercised on the **next release-cutting merge to master** after this PR lands.

## Background

Node 20 is being removed from GitHub Actions runners in Fall 2026 (see [GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). This PR pre-emptively bumps every pinned third-party action to its first Node-24-compatible release so the workflows keep running on the new runner default and downstream consumers stop seeing the deprecation warning bank in their job logs.
