### PR TITLE
chore(ci): swap release-please path to step-security fork on node 24

### DIFF
--- a/.github/workflows/conventional-commit-release.yaml
+++ b/.github/workflows/conventional-commit-release.yaml
@@ -246,17 +246,54 @@ jobs:
 
             core.setOutput("changelog-types-json", JSON.stringify(changelogTypes));
 
-      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3.7.13
+      # Build the JSON object passed to OSS v6 as `config-overrides-json`. The
+      # OSS fork dropped the v3-era inline action inputs (changelog-types,
+      # include-v-in-tag, pull-request-title-pattern, extra-files, package-name)
+      # and accepts them as a single JSON string instead. `release-type` + this
+      # JSON makes release-please run in inline-config mode
+      # (Manifest.fromConfig), preserving the v3 behavior without requiring
+      # callers to commit a release-please-config.json file.
+      - name: Build release-please config-overrides JSON
+        id: build-config-overrides
+        env:
+          PKG_NAME: ${{ github.event.repository.name }}
+          CHANGELOG_SECTIONS: ${{ steps.merge-changelog-types.outputs.changelog-types-json }}
+          INCLUDE_V_IN_TAG: ${{ inputs.include_v_in_tag }}
+          PR_TITLE_PATTERN: ${{ inputs.pull_request_title_template }}
+          EXTRA_FILES: ${{ inputs.extra_files }}
+        run: |
+          # v3 accepted extra-files as a newline- or comma-separated string;
+          # OSS v6 expects a JSON array. Split on either delimiter, trim
+          # per-entry whitespace so "a, b, c" -> ["a","b","c"], drop blanks.
+          if [ -n "${EXTRA_FILES:-}" ]; then
+            extra_files_json=$(printf '%s\n' "$EXTRA_FILES" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sed '/^$/d' | jq -R . | jq -s -c .)
+          else
+            extra_files_json='[]'
+          fi
+
+          overrides=$(jq -n -c \
+            --arg pkg "$PKG_NAME" \
+            --argjson sections "$CHANGELOG_SECTIONS" \
+            --argjson v_in_tag "$INCLUDE_V_IN_TAG" \
+            --arg pr_title "$PR_TITLE_PATTERN" \
+            --argjson extra_files "$extra_files_json" \
+            '{
+              "package-name": $pkg,
+              "changelog-sections": $sections,
+              "include-v-in-tag": $v_in_tag,
+              "pull-request-title-pattern": $pr_title,
+              "extra-files": $extra_files
+            }')
+
+          echo "json=$overrides" >> "$GITHUB_OUTPUT"
+
+      - uses: step-security/release-please-action-oss@af33b76a7bcd035c1d8837e0190cbf85f719e158 # v6.0.2
         id: release
         with:
-          default-branch: ${{ github.event.repository.default_branch }}
-          release-type: ${{ inputs.release_type }}
-          package-name: ${{ github.event.repository.name }}
-          changelog-types: ${{ steps.merge-changelog-types.outputs.changelog-types-json }}
-          include-v-in-tag: ${{ inputs.include_v_in_tag }}
-          pull-request-title-pattern: ${{ inputs.pull_request_title_template }}
-          extra-files: ${{ inputs.extra_files }}
           token: ${{ secrets.RELEASE_TOKEN }}
+          target-branch: ${{ github.event.repository.default_branch }}
+          release-type: ${{ inputs.release_type }}
+          config-overrides-json: ${{ steps.build-config-overrides.outputs.json }}
 
 
       - name: Checkout Release Branch


### PR DESCRIPTION
## Summary

Replaces `google-github-actions/release-please-action@v3.7.13` (Node 16, archived upstream) with `step-security/release-please-action-oss@v6.0.2` (Node 24, StepSecurity-maintained fork of release-please-oss v6.0.2) in the `release:` job of `conventional-commit-release.yaml`. Eliminates the last Node 16 runtime dependency in this workflow.

## Why

Every downstream call to this reusable workflow emits a "Node 20 is being deprecated" warning today because GitHub is force-upgrading the release-please-action's Node 16 runtime to Node 24 during the deprecation grace period. Once GitHub retires the auto-upgrade path (see <https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/>), those runs will fail hard.

Example downstream run: <https://github.com/circlefin/circle-ooak/actions/runs/28517949604> — the log shows Node 16 → 24 auto-forcing on this workflow.

## Why this specific action

`step-security/release-please-action-oss@v6.0.2` is a security-maintained direct fork of `release-please-oss/release-please-action@v6.0.2`:
- same v6.0.2 tag, same JS source
- `comm` diff of `action.yml` inputs → zero drift (including `config-overrides-json`, the input needed to preserve v3-era inline calls)
- Node 24 runtime
- covered by the org-wide `step-security/*` wildcard allowlist in the StepSecurity actions policy — no allowlist PR needed

## What changes for callers

**Zero workflow-input changes.** Every v3 inline action input (`changelog-types`, `include-v-in-tag`, `pull-request-title-pattern`, `extra-files`, `package-name`) is preserved as a reusable-workflow input and translated into a single `config-overrides-json` JSON string built in a new `build-config-overrides` step. The four downstream callers (`circle-nodejs-sdk`, `buidl-wallet-contracts`, `terraform-provider-quicknode`, `circle-ooak`) need no changes.

## Translation table

| v3 input | v6 destination |
|---|---|
| `default-branch` | `target-branch` (renamed in v6) |
| `changelog-types` | `config-overrides-json.changelog-sections` |
| `include-v-in-tag` | `config-overrides-json.include-v-in-tag` |
| `pull-request-title-pattern` | `config-overrides-json.pull-request-title-pattern` |
| `extra-files` (string) | `config-overrides-json.extra-files` (JSON array — normalized in-workflow with per-entry whitespace trim) |
| `package-name` | `config-overrides-json.package-name` |
| `release-type`, `token` | same-name v6 native inputs |

`release-type` + `config-overrides-json` puts release-please in inline-config mode (`Manifest.fromConfig`), preserving v3 behavior without requiring callers to commit a `release-please-config.json` file.

## Output compatibility

For a single-component (root path `.`) release, per-path outputs (`release_created`, `tag_name`, `major`, `minor`, `pr`) are emitted unprefixed at the step level via `setPathOutput('.', key, val)` → `core.setOutput(key, val)`, matching the v3 shape. That preserves:

- The job-level `release_created` output → workflow-level `release_created` output → consumer references like `needs.release-please.outputs.release_created`.
- `Create additional tags` step's `steps.release.outputs.major` / `.minor` references.
- `Checkout Release Branch` step's `fromJson(steps.release.outputs.pr).headBranchName` parse — `pr` is the first `PullRequest` object from release-please core, which still defines `headBranchName`.

## Test plan

- [ ] CI green
- [ ] After merge, one of the four downstream callers runs release-please and produces an equivalent release PR / tag shape
- [ ] Deprecation warning gone from downstream runs